### PR TITLE
double-quoting of non-latin "All servers" message fix

### DIFF
--- a/classes/Misc.php
+++ b/classes/Misc.php
@@ -1949,7 +1949,7 @@
 			
 			$grps['all'] = array(
 				'id' => 'all', 
-				'desc' => $lang['strallservers'],
+				'desc' => noEscape($lang['strallservers']),
 			);
 
 			include_once('./classes/ArrayRecordSet.php');

--- a/libraries/decorator.inc.php
+++ b/libraries/decorator.inc.php
@@ -69,6 +69,10 @@ function value(&$var, &$fields, $esc = null) {
 	} else {
 		$val =& $var;
 	}
+    if (is_a($val, 'Decorator')) {
+        if (!$val->esc) $esc = null;
+        $val = $val->value(null);
+    }
 	if (is_string($val)) {
 		switch($esc) {
 			case 'xml':


### PR DESCRIPTION
Hello!
I've tried to use server grouping feature from the latest git sources and got this: http://dl.dropbox.com/u/598674/ppa-dquot.png

The problem is because of mixing non-quoted groups descriptions with already quoted lang[] message "All servers" in the same list.
I've wrapped lang[] message with a noEscape Decorator  and updated tree-encoder to understand it.

So if this fix is ok, it would be nice to merge one into the main repository.

---

Best Regards,
Denis Orlikhin
qbikk@yandex.com
