### PR TITLE
php7 fixes - fix constructors and 2 common notices

### DIFF
--- a/classes/ArrayRecordSet.php
+++ b/classes/ArrayRecordSet.php
@@ -11,8 +11,8 @@ class ArrayRecordSet {
 	var $_count;
 	var $EOF = false;
 	var $fields;
-	
-	function ArrayRecordSet($data) {
+
+	function __construct($data) {
 		$this->_array = $data;
 		$this->_count = count($this->_array);
 		$this->fields = reset($this->_array);

--- a/classes/Gui.php
+++ b/classes/Gui.php
@@ -7,11 +7,6 @@
 	 class GUI {
 
 		/**
-		 *Constructor
-		 */
-		function GUI () {}
-		 
-		/**
 		 * Prints a combox box
 		 * @param $arrOptions associative array storing options and values of combo should be Option => Value
 		 * @param $szName string to specify the name of the form element

--- a/classes/Misc.php
+++ b/classes/Misc.php
@@ -11,10 +11,6 @@
 		// Tracking string to include in forms
 		var $form;
 
-		/* Constructor */
-		function Misc() {
-		}
-
 		/**
 		 * Checks if dumps are properly set up
 		 * @param $all (optional) True to check pg_dumpall, false to just check pg_dump
@@ -1929,6 +1925,9 @@
 							if (sizeof($actions) > 0) echo "<th class=\"data\" colspan=\"", count($actions), "\">{$column['title']}</th>\n";
 							break;
 						default:
+							if (!isset($column['class']))
+								$column['class'] = '';
+
 							echo "<th class=\"data {$column['class']}\">";
 							if (isset($column['help']))
 								$this->printHelp($column['title'], $column['help']);
@@ -1959,6 +1958,8 @@
 					}
 
 					foreach ($columns as $column_id => $column) {
+						if (!isset($column['class']))
+							$column['class'] = '';
 
 						$class = $column['class'] !== '' ? " class=\"{$column['class']}\"":'';
 

--- a/classes/class.select.php
+++ b/classes/class.select.php
@@ -159,7 +159,7 @@ class XHtmlElement extends XHtmlSimpleElement {
 
 class XHTML_Button extends XHtmlElement {
 	function __construct ($name, $text = null) {
-		parent::XHtmlElement();
+		parent::__construct();
 		
 		$this->set_attribute("name", $name);
 		

--- a/classes/class.select.php
+++ b/classes/class.select.php
@@ -24,8 +24,7 @@ class XHtmlSimpleElement {
 	* derived class
 	* 
 	*/
-	function XHtmlSimpleElement($element = null) {
-
+	function __construct($element = null) {
 		$this->_element = $this->is_element();
 		
 	}
@@ -93,8 +92,8 @@ class XHtmlElement extends XHtmlSimpleElement {
 	var $_htmlcode = "";
 	var $_siblings = array();
 
-	function XHtmlElement($text = null) {
-		XHtmlSimpleElement::XHtmlSimpleElement();
+	function __construct($text = null) {
+		parent::__construct();
 		
 		if ($text) $this->set_text($text);
 	}
@@ -159,7 +158,7 @@ class XHtmlElement extends XHtmlSimpleElement {
 }
 
 class XHTML_Button extends XHtmlElement {
-	function XHTML_Button ($name, $text = null) {
+	function __construct ($name, $text = null) {
 		parent::XHtmlElement();
 		
 		$this->set_attribute("name", $name);
@@ -170,8 +169,8 @@ class XHTML_Button extends XHtmlElement {
 
 
 class XHTML_Option extends XHtmlElement {
-	function XHTML_Option($text, $value = null) {
-		XHtmlElement::XHtmlElement(null);			
+	function __construct($text, $value = null) {
+		parent::__construct(null);
 		$this->set_text($text);
 	}
 }
@@ -180,8 +179,8 @@ class XHTML_Option extends XHtmlElement {
 class XHTML_Select extends XHTMLElement {
 	var $_data;
 
-	function XHTML_Select ($name, $multiple = false, $size = null) {
-		XHtmlElement::XHtmlElement();					
+	function __construct($name, $multiple = false, $size = null) {
+		parent::__construct();
 
 		$this->set_attribute("name", $name);
 		if ($multiple) $this->set_attribute("multiple","multiple");

--- a/classes/database/ADODB_base.php
+++ b/classes/database/ADODB_base.php
@@ -20,7 +20,7 @@ class ADODB_base {
 	 * Base constructor
 	 * @param &$conn The connection object
 	 */
-	function ADODB_base(&$conn) {
+	function __construct(&$conn) {
 		$this->conn = $conn;
 	}
 

--- a/classes/database/Connection.php
+++ b/classes/database/Connection.php
@@ -19,7 +19,7 @@ class Connection {
 	 * Creates a new connection.  Will actually make a database connection.
 	 * @param $fetchMode Defaults to associative.  Override for different behaviour
 	 */
-	function Connection($host, $port, $sslmode, $user, $password, $database, $fetchMode = ADODB_FETCH_ASSOC) {
+	function __construct($host, $port, $sslmode, $user, $password, $database, $fetchMode = ADODB_FETCH_ASSOC) {
 		$this->conn = ADONewConnection('postgres7');
 		$this->conn->setFetchMode($fetchMode);
 

--- a/classes/database/Postgres.php
+++ b/classes/database/Postgres.php
@@ -165,14 +165,6 @@ class Postgres extends ADODB_base {
 	// The default type storage
 	var $typStorageDef = 'plain';
 
-	/**
-	 * Constructor
-	 * @param $conn The database connection
-	 */
-	function Postgres($conn) {
-		$this->ADODB_base($conn);
-	}
-
 	// Formatting functions
 
 	/**

--- a/classes/database/Postgres74.php
+++ b/classes/database/Postgres74.php
@@ -24,15 +24,6 @@ class Postgres74 extends Postgres80 {
 		'schema' => array('CREATE', 'USAGE', 'ALL PRIVILEGES')
 	);
 
-
-	/**
-	 * Constructor
-	 * @param $conn The database connection
-	 */
-	function Postgres74($conn) {
-		$this->Postgres80($conn);
-	}
-
 	// Help functions
 
 	function getHelpPages() {

--- a/classes/database/Postgres80.php
+++ b/classes/database/Postgres80.php
@@ -46,14 +46,6 @@ class Postgres80 extends Postgres81 {
 		'WIN1256' => 'CP1256'
 	);
 
-	/**
-	 * Constructor
-	 * @param $conn The database connection
-	 */
-	function Postgres80($conn) {
-		$this->Postgres81($conn);
-	}
-
 	// Help functions
 
 	function getHelpPages() {

--- a/classes/database/Postgres81.php
+++ b/classes/database/Postgres81.php
@@ -41,16 +41,8 @@ class Postgres81 extends Postgres82 {
 	// Array of allowed index types
 	var $typIndexes = array('BTREE', 'RTREE', 'GIST', 'HASH');
 
-	/**
-	 * Constructor
-	 * @param $conn The database connection
-	 */
-	function Postgres81($conn) {
-		$this->Postgres82($conn);
-	}
-
 	// Help functions
-	
+
 	function getHelpPages() {
 		include_once('./help/PostgresDoc81.php');
 		return $this->help_page;

--- a/classes/database/Postgres82.php
+++ b/classes/database/Postgres82.php
@@ -18,14 +18,6 @@ class Postgres82 extends Postgres83 {
 		'NOT SIMILAR TO' => 'i', '~' => 'i', '!~' => 'i', '~*' => 'i', '!~*' => 'i',
 		'IS NULL' => 'p', 'IS NOT NULL' => 'p', 'IN' => 'x', 'NOT IN' => 'x');
 
-	/**
-	 * Constructor
-	 * @param $conn The database connection
-	 */
-	function Postgres82($conn) {
-		$this->Postgres($conn);
-	}
-
 	// Help functions
 
 	function getHelpPages() {

--- a/classes/database/Postgres83.php
+++ b/classes/database/Postgres83.php
@@ -41,14 +41,6 @@ class Postgres83 extends Postgres84 {
   		'c' => 'CONNECT'
 	);
 
-	/**
-	 * Constructor
-	 * @param $conn The database connection
-	 */
-	function Postgres83($conn) {
-		$this->Postgres($conn);
-	}
-
 	// Help functions
 
 	function getHelpPages() {

--- a/classes/database/Postgres84.php
+++ b/classes/database/Postgres84.php
@@ -26,14 +26,6 @@ class Postgres84 extends Postgres90 {
 		'column' => array('SELECT', 'INSERT', 'UPDATE', 'REFERENCES','ALL PRIVILEGES')
 	);
 
-	/**
-	 * Constructor
-	 * @param $conn The database connection
-	 */
-	function Postgres84($conn) {
-		$this->Postgres($conn);
-	}
-
 	// Help functions
 
 	function getHelpPages() {

--- a/classes/database/Postgres90.php
+++ b/classes/database/Postgres90.php
@@ -12,14 +12,6 @@ class Postgres90 extends Postgres91 {
 
 	var $major_version = 9.0;
 
-	/**
-	 * Constructor
-	 * @param $conn The database connection
-	 */
-	function Postgres90($conn) {
-		$this->Postgres($conn);
-	}
-
 	// Help functions
 
 	function getHelpPages() {

--- a/classes/database/Postgres91.php
+++ b/classes/database/Postgres91.php
@@ -12,14 +12,6 @@ class Postgres91 extends Postgres92 {
 
 	var $major_version = 9.1;
 
-	/**
-	 * Constructor
-	 * @param $conn The database connection
-	 */
-	function Postgres91($conn) {
-		$this->Postgres($conn);
-	}
-
 	// Help functions
 
 	function getHelpPages() {

--- a/classes/database/Postgres92.php
+++ b/classes/database/Postgres92.php
@@ -11,14 +11,6 @@ class Postgres92 extends Postgres {
 
 	var $major_version = 9.2;
 
-	/**
-	 * Constructor
-	 * @param $conn The database connection
-	 */
-	function Postgres92($conn) {
-		$this->Postgres($conn);
-	}
-
 	// Help functions
 
 	function getHelpPages() {

--- a/constraints.php
+++ b/constraints.php
@@ -158,7 +158,7 @@
 
 				if ($attrs->recordCount() > 0) {
 					while (!$attrs->EOF) {
-						$selColumns->add(new XHTML_Option($attrs->fields['attname']));
+						$selColumns->add($x=new XHTML_Option($attrs->fields['attname']));
 						$attrs->moveNext();
 					}
 				}

--- a/libraries/adodb/adodb.inc.php
+++ b/libraries/adodb/adodb.inc.php
@@ -234,7 +234,7 @@
 	
 		var $createdir = true; // requires creation of temp dirs
 		
-		function ADODB_Cache_File()
+		function __construct()
 		{
 		global $ADODB_INCLUDED_CSV;
 			if (empty($ADODB_INCLUDED_CSV)) include_once(ADODB_DIR.'/adodb-csvlib.inc.php');
@@ -427,7 +427,7 @@
 	/**
 	 * Constructor
 	 */
-	function ADOConnection()			
+	function __construct()
 	{
 		die('Virtual Class -- cannot instantiate');
 	}
@@ -2896,7 +2896,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 	 * @param queryID  	this is the queryID returned by ADOConnection->_query()
 	 *
 	 */
-	function ADORecordSet($queryID) 
+	function __construct($queryID)
 	{
 		$this->_queryID = $queryID;
 	}
@@ -3887,13 +3887,13 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 		 * Constructor
 		 *
 		 */
-		function ADORecordSet_array($fakeid=1)
+		function __construct($fakeid=1)
 		{
 		global $ADODB_FETCH_MODE,$ADODB_COMPAT_FETCH;
 		
 			// fetch() on EOF does not delete $this->fields
 			$this->compat = !empty($ADODB_COMPAT_FETCH);
-			$this->ADORecordSet($fakeid); // fake queryID		
+			parent::__construct($fakeid); // fake queryID
 			$this->fetchMode = $ADODB_FETCH_MODE;
 		}
 		

--- a/libraries/adodb/drivers/adodb-postgres64.inc.php
+++ b/libraries/adodb/drivers/adodb-postgres64.inc.php
@@ -117,7 +117,7 @@ WHERE relkind in ('r','v') AND (c.relname='%s' or c.relname = lower('%s'))
 	// to know what the concequences are. The other values are correct (wheren't in 0.94)
 	// -- Freek Dijkstra 
 
-	function ADODB_postgres64() 
+	function __construct() 
 	{
 	// changes the metaColumnsSQL, adds columns: attnum[6]
 	}
@@ -873,7 +873,7 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 	var $_blobArr;
 	var $databaseType = "postgres64";
 	var $canSeek = true;
-	function ADORecordSet_postgres64($queryID,$mode=false) 
+	function __construct($queryID,$mode=false) 
 	{
 		if ($mode === false) { 
 			global $ADODB_FETCH_MODE;

--- a/libraries/adodb/drivers/adodb-postgres64.inc.php
+++ b/libraries/adodb/drivers/adodb-postgres64.inc.php
@@ -889,7 +889,7 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 		default: $this->fetchMode = PGSQL_BOTH; break;
 		}
 		$this->adodbFetchMode = $mode;
-		$this->ADORecordSet($queryID);
+		parent::__construct($queryID);
 	}
 	
 	function GetRowAssoc($upper=true)

--- a/libraries/adodb/drivers/adodb-postgres7.inc.php
+++ b/libraries/adodb/drivers/adodb-postgres7.inc.php
@@ -22,9 +22,9 @@ class ADODB_postgres7 extends ADODB_postgres64 {
 	var $ansiOuter = true;
 	var $charSet = true; //set to true for Postgres 7 and above - PG client supports encodings
 	
-	function ADODB_postgres7() 
+	function __construct() 
 	{
-		$this->ADODB_postgres64();
+		parent::__construct();
 		if (ADODB_ASSOC_CASE !== 2) {
 			$this->rsPrefix .= 'assoc_';
 		}
@@ -213,13 +213,8 @@ class ADODB_postgres7 extends ADODB_postgres64 {
 class ADORecordSet_postgres7 extends ADORecordSet_postgres64{
 
 	var $databaseType = "postgres7";
-	
-	
-	function ADORecordSet_postgres7($queryID,$mode=false) 
-	{
-		$this->ADORecordSet_postgres64($queryID,$mode);
-	}
-	
+
+
 	 	// 10% speedup to move MoveNext to child class
 	function MoveNext() 
 	{
@@ -244,13 +239,8 @@ class ADORecordSet_postgres7 extends ADORecordSet_postgres64{
 class ADORecordSet_assoc_postgres7 extends ADORecordSet_postgres64{
 
 	var $databaseType = "postgres7";
-	
-	
-	function ADORecordSet_assoc_postgres7($queryID,$mode=false) 
-	{
-		$this->ADORecordSet_postgres64($queryID,$mode);
-	}
-	
+
+
 	function _fetch()
 	{
 		if ($this->_currentRow >= $this->_numOfRows && $this->_numOfRows >= 0)

--- a/libraries/decorator.inc.php
+++ b/libraries/decorator.inc.php
@@ -91,10 +91,10 @@ function value_url(&$var, &$fields) {
 
 class Decorator
 {
-	function Decorator($value) {
+	function __construct($value) {
 		$this->v = $value;
 	}
-	
+
 	function value($fields) {
 		return $this->v;
 	}
@@ -102,11 +102,11 @@ class Decorator
 
 class FieldDecorator extends Decorator
 {
-	function FieldDecorator($fieldName, $default = null) {
+	function __construct($fieldName, $default = null) {
 		$this->f = $fieldName;
 		if ($default !== null) $this->d = $default;
 	}
-	
+
 	function value($fields) {
 		return isset($fields[$this->f]) ? value($fields[$this->f], $fields) : (isset($this->d) ? $this->d : null);
 	}
@@ -114,10 +114,10 @@ class FieldDecorator extends Decorator
 
 class ArrayMergeDecorator extends Decorator
 {
-	function ArrayMergeDecorator($arrays) {
+	function __construct($arrays) {
 		$this->m = $arrays;
 	}
-	
+
 	function value($fields) {
 		$accum = array();
 		foreach($this->m as $var) {
@@ -129,10 +129,10 @@ class ArrayMergeDecorator extends Decorator
 
 class ConcatDecorator extends Decorator
 {
-	function ConcatDecorator($values) {
+	function __construct($values) {
 		$this->c = $values;
 	}
-	
+
 	function value($fields) {
 		$accum = '';
 		foreach($this->c as $var) {
@@ -144,11 +144,11 @@ class ConcatDecorator extends Decorator
 
 class CallbackDecorator extends Decorator
 {
-	function CallbackDecorator($callback, $param = null) {
+	function __construct($callback, $param = null) {
 		$this->fn = $callback;
 		$this->p = $param;
 	}
-	
+
 	function value($fields) {
 		return call_user_func($this->fn, $fields, $this->p);
 	}
@@ -156,12 +156,12 @@ class CallbackDecorator extends Decorator
 
 class IfEmptyDecorator extends Decorator
 {
-	function IfEmptyDecorator($value, $empty, $full = null) {
+	function __construct($value, $empty, $full = null) {
 		$this->v = $value;
 		$this->e = $empty;
 		if ($full !== null) $this->f = $full;
 	}
-	
+
 	function value($fields) {
 		$val = value($this->v, $fields);
 		if (empty($val))
@@ -173,7 +173,7 @@ class IfEmptyDecorator extends Decorator
 
 class UrlDecorator extends Decorator
 {
-	function UrlDecorator($base, $queryVars = null) {
+	function __construct($base, $queryVars = null) {
 		$this->b = $base;
 		if ($queryVars !== null)
 			$this->q = $queryVars;
@@ -199,7 +199,7 @@ class UrlDecorator extends Decorator
 
 class replaceDecorator extends Decorator
 {
-	function replaceDecorator($str, $params) {
+	function __construct($str, $params) {
 		$this->s = $str;
 		$this->p = $params;
 	}

--- a/tests/simpletests/testcase/Common/CommonGroupTest.php
+++ b/tests/simpletests/testcase/Common/CommonGroupTest.php
@@ -17,7 +17,7 @@ require_once('ImportTest.php');
  */
 class CommonGroupTest extends GroupTest
 {
-    function CommonGroupTest()
+    function __construct()
     {
         $this->GroupTest('Common manipulation group test.');
         $this->addTestClass(new SecurityTest());

--- a/tests/simpletests/testcase/Schemas/SchemasGroupTest.php
+++ b/tests/simpletests/testcase/Schemas/SchemasGroupTest.php
@@ -24,7 +24,7 @@ require_once('ConversionTest.php');
  */
 class SchemasGroupTest extends GroupTest
 {
-    function SchemasGroupTest() 
+    function __construct() 
     {
     	$this->GroupTest('Schema management group test.');
 

--- a/tests/simpletests/testcase/Server/ServerGroupTest.php
+++ b/tests/simpletests/testcase/Server/ServerGroupTest.php
@@ -18,7 +18,7 @@ require_once('TableSpacesTest.php');
  */
 class ServerGroupTest extends GroupTest
 {
-    function ServerGroupTest() 
+    function __construct() 
     {
         $this->GroupTest('Server management group test.');
         $this->addTestClass(new UsersTest());

--- a/tests/simpletests/testcase/Tables/TableGroupTest.php
+++ b/tests/simpletests/testcase/Tables/TableGroupTest.php
@@ -18,7 +18,7 @@ require_once('DeadlockTest.php');
  *  Group test class to run all test cases in the table function area automatically. 
  */
 class TableGroupTest extends GroupTest {
-    function TableGroupTest() {
+    function __construct() {
         $this->GroupTest('Table management group test.');
         $this->addTestClass(new ColumnTest());        
         $this->addTestClass(new TriggersTest());

--- a/tests/simpletests/testcase/testphpPgAdminMain.php
+++ b/tests/simpletests/testcase/testphpPgAdminMain.php
@@ -26,7 +26,7 @@ require_once('Common/CommonGroupTest.php');
  */
 class phpPgAdminGroupTest extends GroupTest
 {
-    function phpPgAdminGroupTest() 
+    function __construct()
     {
 		$this->GroupTest('phpPgAdmin automation test.');
 		$this->addTestClass(new ServerGroupTest());


### PR DESCRIPTION
I've fixed all old-style constructors and 2 notices I saw frequently (in `classes/Misc.php`). This change is backwards compatible with PHP_VERSION > PHP4 (which I hope no-one still runs)
